### PR TITLE
Also quote arguments with spaces

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -36,7 +36,7 @@ func (gdb *Gdb) Send(operation string, arguments ...string) (map[string]interfac
 		// quote the argument only if needed because GDB interprets un/quoted
 		// values differently in some contexts, e.g., when the value is a
 		// number('1' vs '"1"') or an option ('--thread' vs '"--thread"')
-		if strings.ContainsAny(argument, "\a\b\f\n\r\t\v\\'\"") {
+		if strings.ContainsAny(argument, "\a\b\f\n\r\t\v\\'\" ") {
 			argument = strconv.Quote(argument)
 		}
 		buffer.WriteString(argument)


### PR DESCRIPTION
Since commit 3c9651c ("Avoid unnecessary argument quotation"), not all
arguments are quoted, only those containing specific special characters.
This caused arguments containing spaces to no longer be quoted, making
gdb interpret them as multiple arguments.